### PR TITLE
Use handsoap gem from rubygems.manageiq.org

### DIFF
--- a/docker-assets/Gemfile
+++ b/docker-assets/Gemfile
@@ -4,7 +4,7 @@ gem "manageiq-gems-pending", :git => "https://github.com/ManageIQ/manageiq-gems-
 gem "manageiq-smartstate", "~> 0.3.1"
 
 # Modified gems for vmware_web_service.  Setting sources here since they are git references
-gem "handsoap", "~>0.2.5", :require => false, :git => "https://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-5"
+gem "handsoap", "=0.2.5.5", :require => false, :source => "http://rubygems.manageiq.org"
 
 # Load other additional Gemfiles
 #   Developers can create a file ending in .rb under bundler.d/ to specify additional development dependencies


### PR DESCRIPTION
```
Bundler could not find compatible versions for gem "handsoap":
  In Gemfile:
    handsoap (~> 0.2.5)

    manageiq-gems-pending was resolved to 0.1.0, which depends on
      handsoap (= 0.2.5.5)

Could not find gem 'handsoap (= 0.2.5.5)', which is required by gem
'manageiq-gems-pending', in any of the relevant sources:
  https://github.com/ManageIQ/handsoap.git (at v0.2.5-5@b1247a7)
```

Related PR: https://github.com/ManageIQ/manageiq-gems-pending/pull/456