### PR TITLE
Remove postgresql-devel rpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM manageiq/ruby:latest
 
 # gcc-c++ for unf_ext gem
 # git for git based gems
-# postgresql-devel for pg gem (required by manageiq-gems-pending)
-RUN yum -y install --setopt=tsflags=nodocs gcc-c++ git postgresql-devel && \
+RUN yum -y install --setopt=tsflags=nodocs gcc-c++ git && \
     yum clean all
 
 COPY docker-assets/* /opt/manageiq/amazon-smartstate/


### PR DESCRIPTION
`bundle install` doesn't install `pg` gem. In manageiq-gems-pending, `pg` is a development dependency.