### PR TITLE
[WIP] Use ubi8 image and refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,45 @@
-FROM manageiq/ruby:latest
+FROM registry.access.redhat.com/ubi8 as base
 
-# gcc-c++ for unf_ext gem
-# git for git based gems
-RUN yum -y install --setopt=tsflags=nodocs gcc-c++ git && \
-    yum clean all
+ENV app_root=/opt/manageiq/amazon-smartstate
 
-COPY container-assets/* /opt/manageiq/amazon-smartstate/
-WORKDIR /opt/manageiq/amazon-smartstate
+RUN dnf -y --disableplugin=subscription-manager module enable ruby:2.6
+
+######################
+FROM base as gemset
+
+RUN dnf -y --disableplugin=subscription-manager install --setopt=tsflags=nodocs \
+      gcc               \
+      gcc-c++           \
+      git-core          \
+      make              \
+      libxml2-devel     \
+      libxslt-devel     \
+      redhat-rpm-config \
+      ruby-devel        \
+      rubygem-bundler   \
+      rubygems-devel && \
+    dnf clean all
+
+COPY container-assets/* ${app_root}/
+WORKDIR ${app_root}
 
 RUN echo 'gem: --no-ri --no-rdoc --no-document' > /root/.gemrc && \
-    gem install bundler && \
+    bundle config --local path gemset && \
+    bundle config --local bin bin && \
     bundle install --jobs=8
+
+######################
+FROM base
+
+RUN dnf -y --disableplugin=subscription-manager install --setopt=tsflags=nodocs \
+      libxml2            \
+      libxslt            \
+      ruby               \
+      rubygem-bundler && \
+    dnf clean all
+
+ENV PATH="${app_root}/bin:${PATH}"
+COPY --from=gemset ${app_root} ${app_root}
+WORKDIR ${app_root}
 
 CMD bundle exec amazon_ssa_agent


### PR DESCRIPTION
Changes:
- Use ubi8 as the base (was manageiq/ruby)
- Update to ruby 2.6 (was 2.5)
- Install needed development packages only (was installing "development tools" group) - this allows using ubi repo only without any other repos (like CentOS Base/AppStream, epel) and we will not need to update Dockerfile when CentOS minor version changes
- Use multi stage build so the final image doesn't include development packages - this reduces the image size by 40% or so.

Closes #11 